### PR TITLE
Make Node, Node_ and Leaf type synonyms existential

### DIFF
--- a/src/Monarch/Html.purs
+++ b/src/Monarch/Html.purs
@@ -17,19 +17,12 @@ module Monarch.Html
   )
 where
 
-import Prelude
-import Effect                           ( Effect )
-import Type.Row                         ( type (+) )
-import Type.Row                                            as Row
-import Web.HTML                         ( HTMLElement )
-import Monarch.Type.Row                                    as Row
 import Monarch.Html.Facts.Attributes
 import Monarch.Html.Facts.Outputs
 import Monarch.Html.Facts.Properties
 import Monarch.VirtualDom.VirtualDomTree
 import Monarch.VirtualDom.VirtualDomTree as VirtualDomTree
 import Monarch.VirtualDom.VirtualDomTree.Prelude
-import Monarch.VirtualDom.Facts.Hooks
 
 -- Data Type
 
@@ -37,31 +30,19 @@ type Html = VirtualDomTree ()
 
 -- Elements
 
-type HtmlDivR attributes hooks message = R HtmlDivElementProperties (HtmlDivElementOutputs message) attributes hooks
-
-div :: forall r _r attributes hooks slots message
-     . Row.Union r _r (HtmlDivR attributes hooks message)
-    => Row.OptionalRecordCons r "attrs" (HtmlDivElementAttributes ()) attributes
-    => Row.OptionalRecordCons r "hooks" (Hooks message) hooks
-    => Node r slots message
+div :: Node HtmlDivElementProperties HtmlDivElementOutputs HtmlDivElementAttributes
 div = node "div"
 
-div_ :: forall slots message. Node_ slots message
+div_ :: Node_
 div_ = node_ "div"
 
 div' :: forall message. Html message
 div' = node' "div"
 
-type HtmlButtonR attributes hooks message = R HtmlButtonElementProperties (HtmlButtonElementOutputs message) attributes hooks
-
-button :: forall r _r attributes hooks slots message
-        . Row.Union r _r (HtmlButtonR attributes hooks message)
-       => Row.OptionalRecordCons r "attrs" (HtmlButtonElementAttributes ()) attributes
-       => Row.OptionalRecordCons r "hooks" (Hooks message) hooks
-       => Node r slots message
+button :: Node HtmlButtonElementProperties HtmlButtonElementOutputs HtmlButtonElementAttributes
 button = node "button"
 
-button_ :: forall slots message. Node_ slots message
+button_ :: Node_
 button_ = node_ "button"
 
 button' :: forall message. Html message

--- a/src/Monarch/Svg.purs
+++ b/src/Monarch/Svg.purs
@@ -16,11 +16,8 @@ module Monarch.Svg
   )
 where
 
-import Type.Row as Row
-import Monarch.Type.Row as Row
 import Monarch.VirtualDom.VirtualDomTree
 import Monarch.VirtualDom.NS as NS
-import Monarch.VirtualDom.Facts.Hooks
 import Monarch.VirtualDom.VirtualDomTree.Prelude
 import Monarch.Svg.Facts.Attributes
 import Monarch.Svg.Facts.Properties
@@ -32,16 +29,10 @@ type Svg = VirtualDomTree ()
 
 -- Elements
 
-type SvgSvgR attributes hooks message = R SvgSvgElementProperties (SvgSvgElementOutputs message) attributes hooks
-
-svg :: forall r _r attributes hooks slots message
-     . Row.Union r _r (SvgSvgR attributes hooks message)
-    => Row.OptionalRecordCons r "attrs" (SvgSvgElementAttributes ()) attributes
-    => Row.OptionalRecordCons r "hooks" (Hooks message) hooks
-    => Node r slots message
+svg :: Node SvgSvgElementProperties SvgSvgElementOutputs SvgSvgElementAttributes
 svg = nodeNS NS.SVG "svg"
 
-svg_ :: forall slots message. Node_ slots message
+svg_ :: Node_
 svg_ = nodeNS_ NS.SVG "svg"
 
 svg' :: forall message. Svg message

--- a/src/Monarch/VirtualDom/Facts.purs
+++ b/src/Monarch/VirtualDom/Facts.purs
@@ -1,3 +1,14 @@
+{-|
+Module     : Monarch.VirtualDom.Facts
+Maintainer : Mohammad Hasani (the-dr-lazy.github.io) <the-dr-lazy@pm.me>
+Copyright  : (c) 2020 Monarch
+License    : MPL 2.0
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, version 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-}
+
 module Monarch.VirtualDom.Facts where
 
 import Type.Row (type (+))

--- a/src/Monarch/VirtualDom/Facts.purs
+++ b/src/Monarch/VirtualDom/Facts.purs
@@ -1,0 +1,13 @@
+module Monarch.VirtualDom.Facts where
+
+import Type.Row (type (+))
+
+type Facts (properties :: # Type -> # Type)
+           (outputs    :: # Type -> # Type)
+           (attributes :: # Type)
+           (hooks      :: # Type)
+  = properties
+  + outputs
+  + ( attributes :: { | attributes }
+    , hooks      :: { | hooks }
+    )


### PR DESCRIPTION
Recently on #23 I have noticed in PureScript we are able to have constraints in existential type synonyms. So we can use it for reducing the tedious boilerplate for defining `Html` and `Svg` nodes.