### PR TITLE
Fix scheduler time promotion

### DIFF
--- a/src/Monarch/Scheduler.ts
+++ b/src/Monarch/Scheduler.ts
@@ -22,6 +22,6 @@ export function mkScheduler(): Scheduler {
 
     return {
         unsafe_shouldYieldToBrowser: () => performance.now() > state.deadline,
-        unsafe_promoteDeadline: () => (state.deadline = state.deadline + 5),
+        unsafe_promoteDeadline: () => (state.deadline = performance.now() + 5),
     }
 }


### PR DESCRIPTION
This was the weirdest bug in my life since now! The diff work loop called `Scheduler.unsafe_promoteDeadline` until it reaches the `performance.now` and then the diff loop started to work! Also, after leaving the loop in rest for a while, the `performance.now()` promoted and the next diff loop should reach it by the same way!